### PR TITLE
footnote and get rid of questionmark

### DIFF
--- a/methods.tex
+++ b/methods.tex
@@ -110,7 +110,7 @@ without delay or failure and are assumed to reach a lifetime of 60 years.
         2024 & Finland & Hanhikivi & VVER1200 & 1200 \\
         2024 & Hungary & Paks 5 & VVER1200 & 1200 \\
         2025 & Hungary & Paks 6 & VVER1200 & 1200 \\
-        2025 & Bulgaria & Kozloduy 7 & AP1000? & 950 \\
+        2025 & Bulgaria & Kozloduy 7 & AP1000 & 950 \\
         2026 & UK & Hinkley Point C1 & EPR & 1670 \\
         2027 & UK & Hinkley Point C2 & EPR & 1670 \\
         2029 & Poland & Choczewo & N/A & 3000 \\
@@ -119,6 +119,9 @@ without delay or failure and are assumed to reach a lifetime of 60 years.
         2035 & Czech Rep & Temelin 3 & AP1000 & 1200 \\
         2040 & Czech Rep & Temelin 4 & AP1000 & 1200 \\
         \hline
+    \footnote{The fate of many planned reactors are unsure. The proposed reactor types
+              are also unclear. The ones marked `N/A' for type are assumed to the \glspl{PWR}
+              in the simulation.}
     \end{tabular}
     }
     \label{tab:eu_deployment}

--- a/methods.tex
+++ b/methods.tex
@@ -92,12 +92,13 @@ nuclear power in a global \cite{joskow_future_2012} and European context
 under construction. In the simulation, all  planned constructions are completed 
 without delay or failure and are assumed to reach a lifetime of 60 years.  
 
+\pagebreak
 \begin{table}[h]
     \centering
 
     \label{tab:eu_deployment}
     \scalebox{0.9}{
-    \begin{tabular}{ccccr}
+    \begin{tabular}{ccccc}
         \hline
         \textbf{Exp. Operational }&\textbf{Country} &\textbf{Reactor} & \textbf{Type} & \textbf{Gross \gls{MWe}}\\
         \hline
@@ -110,7 +111,7 @@ without delay or failure and are assumed to reach a lifetime of 60 years.
         2024 & Finland & Hanhikivi & VVER1200 & 1200 \\
         2024 & Hungary & Paks 5 & VVER1200 & 1200 \\
         2025 & Hungary & Paks 6 & VVER1200 & 1200 \\
-        2025 & Bulgaria & Kozloduy 7 & AP1000 & 950 \\
+        2025 & Bulgaria & Kozloduy 7 & \footnotemark AP1000 & 950 \\
         2026 & UK & Hinkley Point C1 & EPR & 1670 \\
         2027 & UK & Hinkley Point C2 & EPR & 1670 \\
         2029 & Poland & Choczewo & N/A & 3000 \\
@@ -119,15 +120,17 @@ without delay or failure and are assumed to reach a lifetime of 60 years.
         2035 & Czech Rep & Temelin 3 & AP1000 & 1200 \\
         2040 & Czech Rep & Temelin 4 & AP1000 & 1200 \\
         \hline
-    \footnote{The fate of many planned reactors are uncertain. The proposed reactor types
-              are also unclear. The ones marked `N/A' for type are assumed to the \glspl{PWR}
-              in the simulation.}
     \end{tabular}
     }
     \label{tab:eu_deployment}
-    \caption {Power Reactors under construction and planned.
+    \caption 
+    {Power Reactors under construction and planned.
         Replicated from \cite{world_nuclear_association_nuclear_2017}.}
 \end{table}
+
+    \footnotetext{The fate of many planned reactors are uncertain. The proposed reactor types
+              are also unclear. The ones marked `N/A' for type are assumed to the \glspl{PWR}
+              in the simulation.}
 \FloatBarrier
 
 For each \gls{EU} nation, we categorize the growth trajectory is categorized from

--- a/methods.tex
+++ b/methods.tex
@@ -98,7 +98,7 @@ without delay or failure and are assumed to reach a lifetime of 60 years.
 
     \label{tab:eu_deployment}
     \scalebox{0.9}{
-    \begin{tabular}{ccccc}
+    \begin{tabular}{ccccr}
         \hline
         \textbf{Exp. Operational }&\textbf{Country} &\textbf{Reactor} & \textbf{Type} & \textbf{Gross \gls{MWe}}\\
         \hline

--- a/methods.tex
+++ b/methods.tex
@@ -119,7 +119,7 @@ without delay or failure and are assumed to reach a lifetime of 60 years.
         2035 & Czech Rep & Temelin 3 & AP1000 & 1200 \\
         2040 & Czech Rep & Temelin 4 & AP1000 & 1200 \\
         \hline
-    \footnote{The fate of many planned reactors are unsure. The proposed reactor types
+    \footnote{The fate of many planned reactors are uncertain. The proposed reactor types
               are also unclear. The ones marked `N/A' for type are assumed to the \glspl{PWR}
               in the simulation.}
     \end{tabular}


### PR DESCRIPTION
The question mark is deleted and instead
a footnote explains the uncertainty of predictions.